### PR TITLE
Qt compiles (and works) on Wndows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
 
 if(USE_QT_GUI)
 	set(CMAKE_AUTOMOC ON)
-	find_package(Qt5 COMPONENTS Core Gui Widgets OpenGL REQUIRED)
+	find_package(Qt5 COMPONENTS Core Gui Widgets REQUIRED)
 endif()
 
 # solvespace dependencies
@@ -299,7 +299,7 @@ if(ENABLE_GUI)
     endif()
 
     # Platform-specific
-    if(WIN32)
+    if(WIN32 AND NOT USE_QT_GUI)
         target_sources(solvespace PRIVATE
             platform/guiwin.cpp)
 
@@ -376,7 +376,7 @@ if(ENABLE_GUI)
             ${FONTCONFIG_LIBRARY_DIRS})
         target_link_libraries(solvespace PRIVATE
             ${FONTCONFIG_LIBRARIES}
-            Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
+            Qt5::Core Qt5::Gui Qt5::Widgets)
     else()
         target_sources(solvespace PRIVATE
             platform/guigtk.cpp)
@@ -401,9 +401,9 @@ if(ENABLE_GUI)
     endif()
 endif()
 
+if(ENABLE_CLI)
 # solvespace headless library
 
-if(ENABLE_CLI)
 add_library(solvespace-headless STATIC EXCLUDE_FROM_ALL
     ${solvespace_core_gl_SOURCES}
     platform/guinone.cpp

--- a/src/platform/guiqt.cpp
+++ b/src/platform/guiqt.cpp
@@ -916,6 +916,11 @@ public:
     }
 };
 
+#if defined(WIN32)
+// This interferes with our identifier.
+#    undef CreateWindow
+#endif
+
 WindowRef CreateWindow(Window::Kind kind, WindowRef parentWindow) {
     return std::make_shared<WindowImplQt>(kind,
                 std::static_pointer_cast<WindowImplQt>(parentWindow));


### PR DESCRIPTION
Tested working with AMD64 build with Visual Studio 19, Qt 5.12 and OpenGL 1

Add:
CMAKE_PREFIX_PATH = [path to your Qt]/Qt/Qt5.12.12/5.12.12/msvc2017_64/lib/cmake/Qt5 to CMake to make it work.